### PR TITLE
Update Controller

### DIFF
--- a/Project-Mug/src/main/java/recyclemug/ProjectMug/api/AdminController.java
+++ b/Project-Mug/src/main/java/recyclemug/ProjectMug/api/AdminController.java
@@ -2,19 +2,14 @@ package recyclemug.ProjectMug.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.aspectj.weaver.ast.Or;
-import org.hibernate.criterion.Order;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import recyclemug.ProjectMug.domain.cup.Cup;
-import recyclemug.ProjectMug.domain.cup.CustomerOrder;
-import recyclemug.ProjectMug.domain.cup.PartnerOrder;
 import recyclemug.ProjectMug.domain.order.OrderState;
-import recyclemug.ProjectMug.dto.CupResponseDto;
 import recyclemug.ProjectMug.dto.OrderDto;
+import recyclemug.ProjectMug.dto.OrderSummaryDto;
 import recyclemug.ProjectMug.repository.CupRepository;
-import recyclemug.ProjectMug.repository.CustomerOrderRepository;
 import recyclemug.ProjectMug.repository.PartnerOrderRepository;
 
 import java.util.ArrayList;
@@ -25,6 +20,7 @@ import java.util.List;
 @Slf4j
 public class AdminController {
     private final CupRepository cupRepository;
+    private final PartnerOrderRepository partnerOrderRepository;
 
     @GetMapping("/get-all-cups") // Partner가 admin에게 주문가능한 컵 내역들을 반환
     @PreAuthorize("hasAnyRole('ADMIN','PARTNER')")
@@ -37,5 +33,16 @@ public class AdminController {
             orderDtoList.add(dto);
         }
         return orderDtoList;
+    }
+
+    @GetMapping("/get-order-summary") // Admin Page에 OrderSummary
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    @ResponseBody
+    public OrderSummaryDto getOrderSummary(){
+        int wait = partnerOrderRepository.findPartnerOrder(OrderState.DELIVERY_WAITING).size();
+        int complete = partnerOrderRepository.findPartnerOrder(OrderState.COMPLETE).size();
+        int cancel = partnerOrderRepository.findPartnerOrder(OrderState.CANCEL).size();
+        int total = partnerOrderRepository.findAllPartnerOrder().size();
+        return new OrderSummaryDto(wait,complete,cancel,total);
     }
 }

--- a/Project-Mug/src/main/java/recyclemug/ProjectMug/api/PartnerCupController.java
+++ b/Project-Mug/src/main/java/recyclemug/ProjectMug/api/PartnerCupController.java
@@ -6,28 +6,38 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 import recyclemug.ProjectMug.data.CreateOrderResponse;
 import recyclemug.ProjectMug.data.CreatePartnerCupRequest;
-import recyclemug.ProjectMug.domain.cup.Cup;
 import recyclemug.ProjectMug.domain.cup.PartnerCup;
 import recyclemug.ProjectMug.domain.cup.PartnerOrder;
 import recyclemug.ProjectMug.domain.user.Partner;
 import recyclemug.ProjectMug.exception.NotEnoughStockException;
+import recyclemug.ProjectMug.repository.PartnerCupRepository;
 import recyclemug.ProjectMug.repository.PartnerOrderRepository;
+import recyclemug.ProjectMug.repository.PartnerRepository;
 import recyclemug.ProjectMug.service.PartnerOrderService;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
 @Slf4j
 public class PartnerCupController {
+    private final PartnerRepository partnerRepository;
     private final PartnerOrderService partnerOrderService;
+    private final PartnerCupRepository partnerCupRepository;
     private final PartnerOrderRepository partnerOrderRepository;
+
+    @GetMapping("/partner-cup/{partnerId}")
+    @PreAuthorize("hasAnyRole('ADMIN','PARTNER')")
+    @ResponseBody
+    public List<PartnerCup> getPartnerCup(@RequestParam Long partnerId){
+        Partner partner = partnerRepository.findOne(partnerId);
+        List<PartnerCup> partnerCups = partnerCupRepository.findCupOfPartner(partner);
+        return partnerCups;
+    }
 
     @PostMapping("/partner-cup/add") // partner의 cup 대여 신청을 admin이 승인했을 시 partnerCup 등록
     @PreAuthorize("hasAnyRole('ADMIN')")

--- a/Project-Mug/src/main/java/recyclemug/ProjectMug/api/PartnerOrderApiController.java
+++ b/Project-Mug/src/main/java/recyclemug/ProjectMug/api/PartnerOrderApiController.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import recyclemug.ProjectMug.data.CreateOrderRequest;
 import recyclemug.ProjectMug.data.CreateOrderResponse;
+import recyclemug.ProjectMug.data.DeletePartnerOrderRequest;
 import recyclemug.ProjectMug.domain.cup.Cup;
 import recyclemug.ProjectMug.domain.cup.PartnerOrder;
 import recyclemug.ProjectMug.domain.order.OrderState;
@@ -128,13 +129,13 @@ public class PartnerOrderApiController {
         }
     }
 
-    @DeleteMapping("/partner/cup/order/delete/{orderId}")
+    @DeleteMapping("/partner/cup/order/delete")
     @PreAuthorize("hasAnyRole('ADMIN','PARTNER')")
     @ResponseBody
-    public ResponseEntity<CreateOrderResponse> partnerCupOrderDelete(@RequestParam(required = false) Long orderId){
+    public ResponseEntity<CreateOrderResponse> partnerCupOrderDelete(@RequestBody @Valid DeletePartnerOrderRequest request){
         try {
-            partnerOrderService.removeOrder(orderId);
-            log.info("Delete partner's order : " + orderId);
+            partnerOrderService.removeOrder(request.getOrderId());
+            log.info("Delete partner's order : " + request.getOrderId());
             return new ResponseEntity<>(new CreateOrderResponse("success","Delete complete"),HttpStatus.OK);
         }catch(Exception e){
          log.error("Invalid partner's order");

--- a/Project-Mug/src/main/java/recyclemug/ProjectMug/data/DeletePartnerOrderRequest.java
+++ b/Project-Mug/src/main/java/recyclemug/ProjectMug/data/DeletePartnerOrderRequest.java
@@ -1,0 +1,8 @@
+package recyclemug.ProjectMug.data;
+
+import lombok.Data;
+
+@Data
+public class DeletePartnerOrderRequest {
+    private Long orderId;
+}

--- a/Project-Mug/src/main/java/recyclemug/ProjectMug/dto/OrderSummaryDto.java
+++ b/Project-Mug/src/main/java/recyclemug/ProjectMug/dto/OrderSummaryDto.java
@@ -1,0 +1,17 @@
+package recyclemug.ProjectMug.dto;
+
+import lombok.Data;
+
+@Data
+public class OrderSummaryDto {
+    private int wait;
+    private int complete;
+    private int cancel;
+    private int total;
+    public OrderSummaryDto(int wait,int complete,int cancel,int total){
+        this.wait = wait;
+        this.complete = complete;
+        this.cancel = cancel;
+        this.total = total;
+    }
+}


### PR DESCRIPTION
AdminController에 get-order-summary 추가

/get-order-summary
 - GET
 - admin 화면의 OrderSummary 반환

PartnerCupController에 getPartnerCup 추가

/partner-cup/{partnerId}
 - GET
 - partner의 매장내 컵 현황을 반환

PartnerOrderApiController에 partnerCupOrderDelete 수정
 - DELETE
 - PartnerOrder를 삭제함
 - RequestBody { 'orderId' : Long(PartnerOrder의 pk) } 필요
